### PR TITLE
feat(gdbdiff): use the bootrom code from real pico

### DIFF
--- a/demo/emulator-run.ts
+++ b/demo/emulator-run.ts
@@ -1,14 +1,21 @@
 import * as fs from 'fs';
 import { RP2040 } from '../src';
-import { bootromB1 } from './bootrom';
+//import { bootromB1 } from './bootrom';
 import { loadHex } from './intelhex';
 import { GDBTCPServer } from '../src';
 
 // Create an array with the compiled code of blink
 // Execute the instructions from this array, one by one.
 const hex = fs.readFileSync('hello_uart.hex', 'utf-8');
+//bootromhex taken from pico by "dump ihex memory bootrom.hex 0x0 0x3fff"
+const bootromhex = fs.readFileSync('demo/bootrom.hex', 'utf-8');
 const mcu = new RP2040();
-mcu.loadBootrom(bootromB1);
+let localbootrom = new ArrayBuffer(0x4000);
+let localbootromview8 = new Uint8Array(localbootrom);
+let localbootromview32 = new Uint32Array(localbootrom);
+loadHex(bootromhex, localbootromview8, 0x00000000);
+mcu.loadBootrom(localbootromview32);
+//mcu.loadBootrom(bootromB1);
 loadHex(hex, mcu.flash, 0x10000000);
 
 const gdbServer = new GDBTCPServer(mcu, 3333);
@@ -19,4 +26,4 @@ mcu.uart[0].onByte = (value) => {
 };
 
 mcu.PC = 0x10000000;
-mcu.execute();
+//mcu.execute();

--- a/demo/emulator-run.ts
+++ b/demo/emulator-run.ts
@@ -1,24 +1,33 @@
 import * as fs from 'fs';
 import { RP2040 } from '../src';
-//import { bootromB1 } from './bootrom';
+import { bootromB1 } from './bootrom';
 import { loadHex } from './intelhex';
 import { GDBTCPServer } from '../src';
 
 // Create an array with the compiled code of blink
 // Execute the instructions from this array, one by one.
-const hex = fs.readFileSync('hello_uart.hex', 'utf-8');
-//bootromhex taken from pico by "dump ihex memory bootrom.hex 0x0 0x3fff"
-const bootromhex = fs.readFileSync('demo/bootrom.hex', 'utf-8');
+const hex = fs.readFileSync(
+  '/home/turro/dev/arduino/raspberrypipico/blink2/blink2/Build/blink2.ino.hex',
+  'utf-8'
+);
 const mcu = new RP2040();
-let localbootrom = new ArrayBuffer(0x4000);
-let localbootromview8 = new Uint8Array(localbootrom);
-let localbootromview32 = new Uint32Array(localbootrom);
-loadHex(bootromhex, localbootromview8, 0x00000000);
-mcu.loadBootrom(localbootromview32);
-//mcu.loadBootrom(bootromB1);
+
+//bootromhex taken from pico by gdb running "dump ihex memory bootrom.hex 0x0 0x3fff"
+if (fs.existsSync('demo/bootrom.hex')) {
+  const bootromhex = fs.readFileSync('demo/bootrom.hex', 'utf-8');
+  let localbootrom = new ArrayBuffer(0x4000);
+  let localbootromview8 = new Uint8Array(localbootrom);
+  let localbootromview32 = new Uint32Array(localbootrom);
+  loadHex(bootromhex, localbootromview8, 0x00000000);
+  mcu.loadBootrom(localbootromview32);
+} else {
+  //load the compiled bootrom
+  mcu.loadBootrom(bootromB1);
+}
+
 loadHex(hex, mcu.flash, 0x10000000);
 
-const gdbServer = new GDBTCPServer(mcu, 3333);
+const gdbServer = new GDBTCPServer(mcu, 3334);
 console.log(`RP2040 GDB Server ready! Listening on port ${gdbServer.port}`);
 
 mcu.uart[0].onByte = (value) => {
@@ -26,4 +35,4 @@ mcu.uart[0].onByte = (value) => {
 };
 
 mcu.PC = 0x10000000;
-//mcu.execute();
+mcu.execute();


### PR DESCRIPTION
github published bootrom may differs from bootrom of a real pico.  
dumping (within gdb session)  the bootrom hex from real pico allows a better use of gdbdiff when code jumps to bootrom (i.e. by using hardware divider example)