### PR TITLE
fix(interpolator): fix incorrect rounding in blend mode

### DIFF
--- a/src/interpolator.ts
+++ b/src/interpolator.ts
@@ -117,8 +117,8 @@ export class Interpolator {
     const clamp0 = ctrl0.signed ? sclamp0 : uclamp0;
 
     const alpha1 = result1 & 0xff;
-    const ublend1 = u32(this.base0) + (((alpha1 * (u32(this.base1) - u32(this.base0))) / 256) | 0);
-    const sblend1 = s32(this.base0) + (((alpha1 * (s32(this.base1) - s32(this.base0))) / 256) | 0);
+    const ublend1 = u32(this.base0) + (Math.floor((alpha1 * (u32(this.base1) - u32(this.base0))) / 256) | 0);
+    const sblend1 = s32(this.base0) + (Math.floor((alpha1 * (s32(this.base1) - s32(this.base0))) / 256) | 0);
     const blend1 = ctrl1.signed ? sblend1 : ublend1;
 
     this.smresult0 = u32(result0);


### PR DESCRIPTION
This PR fixes the interpolator so that the SDK examples work correctly:

Project: https://wokwi.com/projects/330762714449183315

Now correctly produces:

```
Interpolator example
9 times table:
9
18
27
36
45
54
63
72
81
90
Masking:
ACCUM0 = 1234abcd
Nibble 0: 0000000d
Nibble 1: 000000c0
Nibble 2: 00000b00
Nibble 3: 0000a000
Nibble 4: 00040000
Nibble 5: 00300000
Nibble 6: 02000000
Nibble 7: 10000000
Masking with sign extension:
Nibble 0: fffffffd
Nibble 1: ffffffc0
Nibble 2: fffffb00
Nibble 3: ffffa000
Nibble 4: 00040000
Nibble 5: 00300000
Nibble 6: 02000000
Nibble 7: 10000000
Lane result crossover:
PEEK0, POP1: 124, 456
PEEK0, POP1: 457, 124
PEEK0, POP1: 125, 457
PEEK0, POP1: 458, 125
PEEK0, POP1: 126, 458
PEEK0, POP1: 459, 126
PEEK0, POP1: 127, 459
PEEK0, POP1: 460, 127
PEEK0, POP1: 128, 460
PEEK0, POP1: 461, 128
Simple blend 1:
500
582
666
748
832
914
998
Simple blend 2:
signed:
-1000
-672
-336
-8
328
656
992
unsigned:
0xfffffc18
0xd5fffd60
0xaafffeb0
0x80fffff8
0x56000148
0x2c000290
0x010003e0
Simple blend 3:
0x00004000
0x0000e800
0xffffe800
Clamp:
-1024   0
-768    0
-512    0
-256    0
0       0
256     64
512     128
768     192
1024    255
Linear interpolation:
0       (0% between 0 and 10)
2       (25% between 0 and 10)
5       (50% between 0 and 10)
7       (75% between 0 and 10)
10      (0% between 10 and -20)
2       (25% between 10 and -20)
-5      (50% between 10 and -20)
-13     (75% between 10 and -20)
-20     (0% between -20 and -1000)
-265    (25% between -20 and -1000)
-510    (50% between -20 and -1000)
-755    (75% between -20 and -1000)
-1000   (0% between -1000 and 500)
-625    (25% between -1000 and 500)
-250    (50% between -1000 and 500)
125     (75% between -1000 and 500)
Linear interpolation 2:
0       (0% between 0 and 10)
1       (12% between 0 and 10)
2       (25% between 0 and 10)
3       (37% between 0 and 10)
5       (50% between 0 and 10)
6       (62% between 0 and 10)
7       (75% between 0 and 10)
8       (87% between 0 and 10)
10      (0% between 10 and -20)
6       (12% between 10 and -20)
2       (25% between 10 and -20)
-2      (37% between 10 and -20)
-5      (50% between 10 and -20)
-9      (62% between 10 and -20)
-13     (75% between 10 and -20)
-17     (87% between 10 and -20)
-20     (0% between -20 and -1000)
-143    (12% between -20 and -1000)
-265    (25% between -20 and -1000)
-388    (37% between -20 and -1000)
-510    (50% between -20 and -1000)
-633    (62% between -20 and -1000)
-755    (75% between -20 and -1000)
-878    (87% between -20 and -1000)
-1000   (0% between -1000 and 500)
-813    (12% between -1000 and 500)
-625    (25% between -1000 and 500)
-438    (37% between -1000 and 500)
-250    (50% between -1000 and 500)
-63     (62% between -1000 and 500)
125     (75% between -1000 and 500)
312     (87% between -1000 and 500)
Affine Texture mapping (with texture wrap):
0x00
0x00
0x01
0x01
0x12
0x12
0x13
0x23
0x20
0x20
0x31
0x31
```

An actual test harness (an `interpolator.spec.ts`) will be added in a later PR.