### PR TITLE
SPI busy flag may cause deadlock

### DIFF
--- a/src/peripherals/pio.ts
+++ b/src/peripherals/pio.ts
@@ -95,7 +95,7 @@ function irqIndex(irq: number, machineIndex: number): number {
 }
 
 const dreqRx0 = [
-  DREQChannel.DREQ_PIO1_RX0,
+  DREQChannel.DREQ_PIO0_RX0,
   DREQChannel.DREQ_PIO0_RX1,
   DREQChannel.DREQ_PIO0_RX2,
   DREQChannel.DREQ_PIO0_RX3,

--- a/src/peripherals/spi.ts
+++ b/src/peripherals/spi.ts
@@ -112,8 +112,8 @@ export class RPSPI extends BasePeripheral implements Peripheral {
   private doTX() {
     if (!this.busy && !this.txFIFO.empty) {
       const value = this.txFIFO.pull();
-      this.onTransmit(value);
       this.busy = true;
+      this.onTransmit(value);
       this.fifosUpdated();
     }
   }


### PR DESCRIPTION
If user call `completeTransmit` in `onTransmit` event, the `busy` flag will be set `false` then `true`. Which may cause emulator waiting for it.