### PR TITLE
check if stdin isTTY prior to setRawMode.

### DIFF
--- a/demo/micropython-run.ts
+++ b/demo/micropython-run.ts
@@ -30,7 +30,9 @@ cdc.onSerialData = (value) => {
   process.stdout.write(value);
 };
 
-process.stdin.setRawMode(true);
+if (process.stdin.isTTY) {
+  process.stdin.setRawMode(true);
+}
 process.stdin.on('data', (chunk) => {
   // 24 is Ctrl+X
   if (chunk[0] === 24) {


### PR DESCRIPTION
I'm trying to launch this emulator from python via `subprocess`. Previously it would complain:

```
process.stdin.setRawMode(true);
              ^
TypeError: process.stdin.setRawMode is not a function
    at Object.<anonymous> (/Users/brianpugh/projects/rp2040js/demo/micropython-run.ts:33:15)
    at Module._compile (node:internal/modules/cjs/loader:1205:14)
    at Module.m._compile (/Users/brianpugh/projects/rp2040js/node_modules/ts-node/src/index.ts:1056:23)
    at Module._extensions..js (node:internal/modules/cjs/loader:1259:10)
    at Object.require.extensions.<computed> [as .ts] (/Users/brianpugh/projects/rp2040js/node_modules/ts-node/src/index.ts:1059:12)
    at Module.load (node:internal/modules/cjs/loader:1068:32)
    at Function.Module._load (node:internal/modules/cjs/loader:909:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:82:12)
    at main (/Users/brianpugh/projects/rp2040js/node_modules/ts-node/src/bin.ts:198:14)
    at Object.<anonymous> (/Users/brianpugh/projects/rp2040js/node_modules/ts-node/src/bin.ts:288:3)

```

This PR seems to fix my problems.