### PR TITLE
fix(adc): add error flag just if an error appeared and 16 bit resolution is configured (therefore byte_shift flag for 8 bit DMA transfers is disabled)

### DIFF
--- a/src/peripherals/adc.ts
+++ b/src/peripherals/adc.ts
@@ -186,8 +186,7 @@ export class RPADC extends BasePeripheral implements Peripheral {
         value &= 0xfff; // 12 bits
         if (this.fcs & FCS_SHIFT) {
           value >>= 4;
-        }
-        if (this.fcs & FCS_ERR) {
+        } else if (error && this.fcs & FCS_ERR) {
           value |= FIFO_ERR;
         }
         this.fifo.push(value);

--- a/src/peripherals/adc.ts
+++ b/src/peripherals/adc.ts
@@ -186,7 +186,8 @@ export class RPADC extends BasePeripheral implements Peripheral {
         value &= 0xfff; // 12 bits
         if (this.fcs & FCS_SHIFT) {
           value >>= 4;
-        } else if (error && this.fcs & FCS_ERR) {
+        } 
+        if (error && this.fcs & FCS_ERR) {
           value |= FIFO_ERR;
         }
         this.fifo.push(value);


### PR DESCRIPTION
At the moment the error flag is always set (15th bit) if full resolution (12 bit) reads are configured which are stored as 2 byte samples in the ADC's FIFO. That is wrong in my opinion because the error flag should just be set if an error appeared. An error appears if the ADC concludes that there was an error after sampling.