### PR TITLE
Cli options "--image" and "--gdb"

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,17 @@ npm install
 npm run start:micropython
 ```
 
-and enjoy the MicroPython REPL! Quit the REPL with Ctrl+X.
+and enjoy the MicroPython REPL! Quit the REPL with Ctrl+X. A different UF2 image can be loaded by supplying the `--image` option:
 
-You can replace rp2-pico-20210902-v1.17.uf2 with any recent MicroPython or CircuitPython release built for the RP2040.
+```
+npm run start:micropython -- --image=my_image.uf2
+```
+
+A GDB server on port 3333 can be enabled by specifying the `--gdb` flag:
+
+```
+npm run start:micropython -- --gdb
+```
 
 With MicroPython – and probably also CircuitPython – you can use the filesystem on the Pico. This becomes useful as more than one script file is used in your code. Just put a [LittleFS](https://github.com/littlefs-project/littlefs) formatted filesystem image called `littlefs.img` into the rp2040js root directory, and your `main.py` will be automatically started from there.
 

--- a/demo/micropython-run.ts
+++ b/demo/micropython-run.ts
@@ -8,22 +8,22 @@ import fs from 'fs';
 import minimist from 'minimist';
 
 const args = minimist(process.argv.slice(2), {
-  string: 'image',  // UF2 image to load; defaults to "rp2-pico-20210902-v1.17.uf2"
-  boolean: 'gdb',  // start GDB server on 3333
-})
+  string: 'image', // UF2 image to load; defaults to "rp2-pico-20210902-v1.17.uf2"
+  boolean: 'gdb', // start GDB server on 3333
+});
 
 const mcu = new RP2040();
 mcu.loadBootrom(bootromB1);
 mcu.logger = new ConsoleLogger(LogLevel.Error);
 
 let imageName: string;
-if(args.image){
+if (args.image) {
   imageName = args.image;
 } else {
   imageName = 'rp2-pico-20210902-v1.17.uf2';
 }
 console.log(`Loading uf2 image ${imageName}`);
-loadUF2(imageName , mcu);
+loadUF2(imageName, mcu);
 
 if (fs.existsSync('littlefs.img')) {
   loadMicropythonFlashImage('littlefs.img', mcu);
@@ -31,7 +31,7 @@ if (fs.existsSync('littlefs.img')) {
   // https://github.com/wokwi/littlefs-wasm or https://github.com/littlefs-project/littlefs-js
 }
 
-if(args.gdb){
+if (args.gdb) {
   const gdbServer = new GDBTCPServer(mcu, 3333);
   console.log(`RP2040 GDB Server ready! Listening on port ${gdbServer.port}`);
 }

--- a/demo/micropython-run.ts
+++ b/demo/micropython-run.ts
@@ -5,25 +5,25 @@ import { ConsoleLogger, LogLevel } from '../src/utils/logging';
 import { bootromB1 } from './bootrom';
 import { loadUF2, loadMicropythonFlashImage } from './load-flash';
 import fs from 'fs';
-const minimist = require('minimist');
+import minimist from 'minimist';
 
 const args = minimist(process.argv.slice(2), {
   string: 'image',  // UF2 image to load; defaults to "rp2-pico-20210902-v1.17.uf2"
-  boolean: 'no_gdb',  // Do NOT start GDB server
+  boolean: 'gdb',  // start GDB server on 3333
 })
 
 const mcu = new RP2040();
 mcu.loadBootrom(bootromB1);
 mcu.logger = new ConsoleLogger(LogLevel.Error);
 
-var image_name: string;
+let imageName: string;
 if(args.image){
-  image_name = args.image;
+  imageName = args.image;
 } else {
-  image_name = 'rp2-pico-20210902-v1.17.uf2';
+  imageName = 'rp2-pico-20210902-v1.17.uf2';
 }
-console.log(`Loading uf2 image ${image_name}`);
-loadUF2(image_name , mcu);
+console.log(`Loading uf2 image ${imageName}`);
+loadUF2(imageName , mcu);
 
 if (fs.existsSync('littlefs.img')) {
   loadMicropythonFlashImage('littlefs.img', mcu);
@@ -31,9 +31,8 @@ if (fs.existsSync('littlefs.img')) {
   // https://github.com/wokwi/littlefs-wasm or https://github.com/littlefs-project/littlefs-js
 }
 
-var gdbServer: GDBTCPServer;
-if(!args.no_gdb){
-  gdbServer = new GDBTCPServer(mcu, 3333);
+if(args.gdb){
+  const gdbServer = new GDBTCPServer(mcu, 3333);
   console.log(`RP2040 GDB Server ready! Listening on port ${gdbServer.port}`);
 }
 

--- a/demo/micropython-run.ts
+++ b/demo/micropython-run.ts
@@ -16,12 +16,7 @@ const mcu = new RP2040();
 mcu.loadBootrom(bootromB1);
 mcu.logger = new ConsoleLogger(LogLevel.Error);
 
-let imageName: string;
-if (args.image) {
-  imageName = args.image;
-} else {
-  imageName = 'rp2-pico-20210902-v1.17.uf2';
-}
+const imageName = args.image ?? 'rp2-pico-20210902-v1.17.uf2';
 console.log(`Loading uf2 image ${imageName}`);
 loadUF2(imageName, mcu);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,10 @@
       "name": "rp2040js",
       "version": "0.17.7",
       "license": "MIT",
+      "dependencies": {
+        "@types/minimist": "^1.2.2",
+        "minimist": "^1.2.7"
+      },
       "devDependencies": {
         "@types/jest": "^27.4.1",
         "@types/node": "^14.14.22",
@@ -1163,6 +1167,11 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
       "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
       "dev": true
+    },
+    "node_modules/@types/minimist": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
+      "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
     },
     "node_modules/@types/node": {
       "version": "14.14.22",
@@ -4510,10 +4519,12 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/mkdirp": {
       "version": "1.0.4",
@@ -6924,6 +6935,11 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
       "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
       "dev": true
+    },
+    "@types/minimist": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
+      "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
     },
     "@types/node": {
       "version": "14.14.22",
@@ -9444,10 +9460,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g=="
     },
     "mkdirp": {
       "version": "1.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,9 @@
       "name": "rp2040js",
       "version": "0.17.7",
       "license": "MIT",
-      "dependencies": {
-        "@types/minimist": "^1.2.2",
-        "minimist": "^1.2.7"
-      },
       "devDependencies": {
         "@types/jest": "^27.4.1",
+        "@types/minimist": "^1.2.2",
         "@types/node": "^14.14.22",
         "@typescript-eslint/eslint-plugin": "^4.22.1",
         "@typescript-eslint/parser": "^4.22.1",
@@ -21,6 +18,7 @@
         "husky": "^6.0.0",
         "jest": "^27.5.1",
         "lint-staged": "^11.0.0",
+        "minimist": "^1.2.7",
         "prettier": "^2.2.1",
         "rimraf": "^3.0.2",
         "ts-jest": "^27.1.3",
@@ -1171,7 +1169,8 @@
     "node_modules/@types/minimist": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
-      "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
+      "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
+      "dev": true
     },
     "node_modules/@types/node": {
       "version": "14.14.22",
@@ -4522,6 +4521,7 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
       "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -6939,7 +6939,8 @@
     "@types/minimist": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
-      "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
+      "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
+      "dev": true
     },
     "@types/node": {
       "version": "14.14.22",
@@ -9462,7 +9463,8 @@
     "minimist": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g=="
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "dev": true
     },
     "mkdirp": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -61,5 +61,9 @@
     "**/*.js": [
       "prettier --write"
     ]
+  },
+  "dependencies": {
+    "@types/minimist": "^1.2.2",
+    "minimist": "^1.2.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "@types/jest": "^27.4.1",
+    "@types/minimist": "^1.2.2",
     "@types/node": "^14.14.22",
     "@typescript-eslint/eslint-plugin": "^4.22.1",
     "@typescript-eslint/parser": "^4.22.1",
@@ -45,6 +46,7 @@
     "husky": "^6.0.0",
     "jest": "^27.5.1",
     "lint-staged": "^11.0.0",
+    "minimist": "^1.2.7",
     "prettier": "^2.2.1",
     "rimraf": "^3.0.2",
     "ts-jest": "^27.1.3",
@@ -61,9 +63,5 @@
     "**/*.js": [
       "prettier --write"
     ]
-  },
-  "dependencies": {
-    "@types/minimist": "^1.2.2",
-    "minimist": "^1.2.7"
   }
 }


### PR DESCRIPTION
PR for issue #114 

Adds CLI options to allows specification of the UF2 image being loaded as well as whether or not to start the GDB server. All default functionality is the same as before. Example usage:


```
npm run start:micropython -- --gdb --image=circuitpython.uf2
```

This is my first time using javascript/typescript, so I would love feedback on if anything in this PR isn't idiomatic.


EDIT: updated title/example command to match changing `--no_gdb` -> `--gdb`.