### PR TITLE
fix systick CVR, was reporting microseconds instead of cycles

### DIFF
--- a/src/peripherals/ppb.ts
+++ b/src/peripherals/ppb.ts
@@ -121,7 +121,7 @@ export class RPPPB extends BasePeripheral implements Peripheral {
         return countFlagValue | (this.systickControl & 0x7);
       }
       case SYST_CVR: {
-        const delta = (rp2040.clock.micros - this.systickLastZero) % (this.systickReload + 1);
+        const delta = (rp2040.core.cycles - this.systickLastZero) % (this.systickReload + 1);
         if (!delta) {
           return 0;
         }


### PR DESCRIPTION
fixes https://github.com/wokwi/wokwi-features/issues/499