### PR TITLE
Report UART status as events; addl UART events

### DIFF
--- a/demo/emulator-run.ts
+++ b/demo/emulator-run.ts
@@ -14,9 +14,9 @@ loadHex(hex, mcu.flash, 0x10000000);
 const gdbServer = new GDBTCPServer(mcu, 3333);
 console.log(`RP2040 GDB Server ready! Listening on port ${gdbServer.port}`);
 
-mcu.uart[0].onByte = (value) => {
+mcu.uart[0].on('byteSent', (value) => {
   process.stdout.write(new Uint8Array([value]));
-};
+});
 
 mcu.core.PC = 0x10000000;
 mcu.execute();

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "rp2040js",
       "version": "0.17.15",
       "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.1"
+      },
       "devDependencies": {
         "@types/jest": "^27.4.1",
         "@types/minimist": "^1.2.2",
@@ -2667,6 +2670,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "node_modules/execa": {
       "version": "5.1.1",
@@ -8057,6 +8065,11 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
+    },
+    "eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "execa": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -65,5 +65,8 @@
     "**/*.js": [
       "prettier --write"
     ]
+  },
+  "dependencies": {
+    "eventemitter3": "^5.0.1"
   }
 }

--- a/src/peripherals/peripheral.ts
+++ b/src/peripherals/peripheral.ts
@@ -1,3 +1,4 @@
+import EventEmitter from 'eventemitter3';
 import { RP2040 } from '../rp2040';
 
 const ATOMIC_NORMAL = 0;
@@ -25,10 +26,15 @@ export interface Peripheral {
   writeUint32Atomic(offset: number, value: number, atomicType: number): void;
 }
 
-export class BasePeripheral implements Peripheral {
+// eslint-disable-next-line @typescript-eslint/ban-types -- EventEmitter3 defines the allowed types as `object`, so copy that here
+export class BasePeripheral<E extends object = Record<string, unknown>>
+  extends EventEmitter<E>
+  implements Peripheral {
   protected rawWriteValue = 0;
 
-  constructor(protected rp2040: RP2040, readonly name: string) {}
+  constructor(protected rp2040: RP2040, readonly name: string) {
+    super();
+  }
 
   readUint32(offset: number) {
     this.warn(`Unimplemented peripheral read from ${offset.toString(16)}`);


### PR DESCRIPTION
This is more flexible & allows for multiple listeners.

The new events allow the user to push data to the UART without a ton of trouble & setTimeouts.

This does introduce a new dependency, `eventemitter3`. This is not really needed for Node, but it is needed on the browser since the browser's events implementation is different than in Node.