### PR TITLE
boost TX_FIFO_SIZE to 300kb

### DIFF
--- a/src/usb/cdc.ts
+++ b/src/usb/cdc.ts
@@ -17,7 +17,7 @@ const CDC_RTS = 1 << 1;
 const CDC_DATA_CLASS = 10;
 const ENDPOINT_BULK = 2;
 
-const TX_FIFO_SIZE = 512;
+const TX_FIFO_SIZE = 1024 * 300;
 
 const ENDPOINT_ZERO = 0;
 const CONFIGURATION_DESCRIPTOR_SIZE = 9;


### PR DESCRIPTION
I wondered why I can't paste into the micropython demo chunks longer than 512 bytes. then I read the code and figured out the fifo is too small, and when pasting data the mcu green thread is starving, and data starts to leak. boosting this const up allows pasting longer text easily.

