### PR TITLE
Run UF2 with `npm start`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ npm install
 npm start
 ```
 
+You can also specify the path to the image on the command line and/or load an UF2 image:
+
+```sh
+npm run start -- --image ./my-pico-project.uf2
+```
+
+A GDB server will be available on port 3333, and the data written to UART0 will be printed
+to the console.
+
 ### MicroPython code
 
 To run the MicroPython demo, first download [RPI_PICO-20230426-v1.20.0.uf2](https://micropython.org/resources/firmware/RPI_PICO-20230426-v1.20.0.uf2), place it in the rp2040js root directory, then run:

--- a/demo/emulator-run.ts
+++ b/demo/emulator-run.ts
@@ -3,14 +3,37 @@ import { GDBTCPServer } from '../src/gdb/gdb-tcp-server.js';
 import { Simulator } from '../src/simulator.js';
 import { bootromB1 } from './bootrom.js';
 import { loadHex } from './intelhex.js';
+import { loadUF2 } from './load-flash.js';
+import minimist from 'minimist';
 
-// Create an array with the compiled code of blink
-// Execute the instructions from this array, one by one.
-const hex = fs.readFileSync('hello_uart.hex', 'utf-8');
+const args = minimist(process.argv.slice(2), {
+  string: [
+    'image', // An image to load, hex and UF2 are supported
+  ],
+});
+
 const simulator = new Simulator();
 const mcu = simulator.rp2040;
 mcu.loadBootrom(bootromB1);
-loadHex(hex, mcu.flash, 0x10000000);
+
+const imageName = args.image ?? 'hello_uart.hex'
+
+// Check the extension of the file
+const extension = imageName.split('.').pop();
+if (extension === 'hex') {
+  // Create an array with the compiled code of blink
+  // Execute the instructions from this array, one by one.
+  const hex = fs.readFileSync(imageName, 'utf-8');
+
+  console.log(`Loading hex image ${imageName}`);
+  loadHex(hex, mcu.flash, 0x10000000);
+} else if (extension === 'uf2') {
+  console.log(`Loading uf2 image ${imageName}`);
+  loadUF2(imageName, mcu);
+} else {
+  console.log(`Unsupported file type: ${extension}`);
+  process.exit(1);
+}
 
 const gdbServer = new GDBTCPServer(simulator, 3333);
 console.log(`RP2040 GDB Server ready! Listening on port ${gdbServer.port}`);


### PR DESCRIPTION
The existing implementtaion of `start` does not accept a path on the command line while it has the feature of relaying UART0 to the console.

Add the command line parameter to specify an arbitrary image, also accept UF2 file, besides hex, preserve backward compat. As a result, images that send output to UART0 can be benefit from that.