### PR TITLE
Improve standalone emulator run cli

### DIFF
--- a/demo/emulator-run.ts
+++ b/demo/emulator-run.ts
@@ -1,37 +1,71 @@
-import * as fs from 'fs';
-import { GDBTCPServer } from '../src/gdb/gdb-tcp-server.js';
-import { Simulator } from '../src/simulator.js';
-import { bootromB1 } from './bootrom.js';
-import { loadHex } from './intelhex.js';
-import { loadUF2 } from './load-flash.js';
-import minimist from 'minimist';
+import * as fs from "fs";
+import minimist from "minimist";
+import packageJson from "../package.json" with { type: "json" };
+import { GDBTCPServer } from "../src/gdb/gdb-tcp-server.js";
+import { RP2040 } from "../src/index.js";
+import { Simulator } from "../src/simulator.js";
+import { bootromB1 } from "./bootrom.js";
+import { loadHex } from "./intelhex.js";
+import { loadUF2 } from "./load-flash.js";
+
+const HELP_MESSAGE = `
+${packageJson.description}
+
+Flags:
+  --image <IMAGE>: The compiled image to load and run in the emulator (.uf2, .hex). If no arguement is provided, look for a file called 'hello_uart.hex' in the current directory.
+  --help: Print this help message.
+  --version: Print the current rp2040js version.
+`;
+
+function loadImage(imageName = "hello_uart.hex", mcu: RP2040) {
+  const extension = imageName.split(".").pop();
+
+  if (extension === "hex") {
+    // Create an array with the compiled code of blink
+    // Execute the instructions from this array, one by one.
+    const hex = fs.readFileSync(imageName, "utf-8");
+    console.log(`Loading hex image ${imageName}`);
+    loadHex(hex, mcu.flash, 0x10000000);
+  } else if (extension === "uf2") {
+    console.log(`Loading uf2 image ${imageName}`);
+    loadUF2(imageName, mcu);
+  } else {
+    console.log(`Unsupported file type: ${extension}`);
+    process.exit(1);
+  }
+}
 
 const args = minimist(process.argv.slice(2), {
   string: [
-    'image', // An image to load, hex and UF2 are supported
+    "image", // An image to load, hex and UF2 are supported
+  ],
+  boolean: [
+    "help",
+    "version",
   ],
 });
+
+if (args.help) {
+  console.log(HELP_MESSAGE);
+  process.exit(0);
+}
+
+if (args.version) {
+  console.log(`rp2040js version: ${packageJson.version}`);
+  process.exit(0);
+}
 
 const simulator = new Simulator();
 const mcu = simulator.rp2040;
 mcu.loadBootrom(bootromB1);
 
-const imageName = args.image ?? 'hello_uart.hex';
+try {
+  loadImage(args.image, mcu);
+} catch (err) {
+  const message = err instanceof Error ? err.message : String(err);
 
-// Check the extension of the file
-const extension = imageName.split('.').pop();
-if (extension === 'hex') {
-  // Create an array with the compiled code of blink
-  // Execute the instructions from this array, one by one.
-  const hex = fs.readFileSync(imageName, 'utf-8');
-
-  console.log(`Loading hex image ${imageName}`);
-  loadHex(hex, mcu.flash, 0x10000000);
-} else if (extension === 'uf2') {
-  console.log(`Loading uf2 image ${imageName}`);
-  loadUF2(imageName, mcu);
-} else {
-  console.log(`Unsupported file type: ${extension}`);
+  console.log(`Failed to load image file: "${message}"`);
+  console.log(HELP_MESSAGE);
   process.exit(1);
 }
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "scripts": {
     "build": "rimraf dist && tsc && tsc -p tsconfig.cjs.json && node build-scripts/dist-package-json",
+    "build:demo": "rimraf dist && tsc -p tsconfig.demo.json",
     "prepublish": "npm run build",
     "prepare": "husky install",
     "format:check": "prettier --check **/*.{ts,js} !**/dist/** !**/node_modules/**",

--- a/tsconfig.demo.json
+++ b/tsconfig.demo.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "./dist",
+    "resolveJsonModule": true
+  },
+  "include": [
+    "src/**/*.ts",
+    "demo/**/*.ts"
+  ],
+  "exclude": [
+    "src/**/*.spec.ts",
+    "demo/**/*.spec.ts"
+  ]
+}


### PR DESCRIPTION
Recently (in #143), the `npm start` script gained the ability to have a `--image` flag passed. I believe this functionality would be quite useful as a standalone packaged program, and hence am in the [process of packaging for nix](https://github.com/NixOS/nixpkgs/pull/413734).

To that end, this pull request implements:
- `--help` and `--version` flags for `demo/emulator-run.ts` to improve the general user experience from the command line.
- A `npm run build:demo` script with it's own `tsconfig.demo.json` for building/running demo scripts as their own programs.