### PR TITLE
feat(pio): implement TX/RX FIFO join (FJOIN_TX / FJOIN_RX)

### DIFF
--- a/src/peripherals/pio.spec.ts
+++ b/src/peripherals/pio.spec.ts
@@ -40,6 +40,7 @@ import {
 } from '../utils/pio-assembler.js';
 
 const CTRL = 0x50200000;
+const FSTAT = 0x50200004;
 const FLEVEL = 0x5020000c;
 const TXF0 = 0x50200010;
 const RXF0 = 0x50200020;
@@ -72,6 +73,7 @@ const RX0_SHIFT = 4;
 
 // SM0_SHIFTCTRL bits:
 const FJOIN_RX = 1 << 30;
+const FJOIN_TX = 1 << 31;
 const IN_SHIFTDIR = 1 << 18;
 const OUT_SHIFTDIR = 1 << 19;
 const SHIFTCTRL_AUTOPULL = 1 << 17;
@@ -88,6 +90,13 @@ const EXECCTRL_STATUS_N_SHIFT = 0;
 
 // FDEBUG bits
 const FDEBUG_TXSTALL = 1 << 24;
+const FDEBUG_TXOVER = 1 << 16;
+
+// FSTAT bits (SM0)
+const FSTAT_RXFULL = 1 << 0;
+const FSTAT_RXEMPTY = 1 << 8;
+const FSTAT_TXFULL = 1 << 16;
+const FSTAT_TXEMPTY = 1 << 24;
 
 const DBG_PADOUT = 0x5020003c;
 
@@ -614,5 +623,61 @@ describe('PIO', () => {
     await cpu.writeUint32(NVIC_ICPR, PIO_IRQ0);
     expect((await cpu.readUint32(INTR)) & INTR_SM0_RXNEMPTY).toEqual(0);
     expect((await cpu.readUint32(NVIC_ISPR)) & PIO_IRQ0).toEqual(0);
+  });
+
+  describe('FIFO join (FJOIN_TX / FJOIN_RX)', () => {
+    it('should provide an 8-deep TX FIFO when FJOIN_TX is set', async () => {
+      await resetStateMachines();
+      await cpu.writeUint32(SM0_SHIFTCTRL, FJOIN_TX);
+
+      // Push 8 words; with the joined FIFO none should overflow
+      for (let i = 0; i < 8; i++) {
+        await cpu.writeUint32(TXF0, 0x1000 + i);
+      }
+      expect((await cpu.readUint32(FLEVEL)) & 0xf).toEqual(8); // TX0 level = 8
+      expect((await cpu.readUint32(FSTAT)) & FSTAT_TXFULL).toEqual(FSTAT_TXFULL);
+      expect((await cpu.readUint32(FSTAT)) & FSTAT_TXEMPTY).toEqual(0);
+
+      // A 9th push overflows and sets the TXOVER flag in FDEBUG
+      await cpu.writeUint32(FDEBUG, 0xffffffff);
+      await cpu.writeUint32(TXF0, 0xdead);
+      expect((await cpu.readUint32(FDEBUG)) & FDEBUG_TXOVER).toEqual(FDEBUG_TXOVER);
+      expect((await cpu.readUint32(FLEVEL)) & 0xf).toEqual(8);
+
+      // The donated RX FIFO is disabled: it reads back as both empty and full
+      expect((await cpu.readUint32(FSTAT)) & FSTAT_RXEMPTY).toEqual(FSTAT_RXEMPTY);
+      expect((await cpu.readUint32(FSTAT)) & FSTAT_RXFULL).toEqual(FSTAT_RXFULL);
+    });
+
+    it('should provide an 8-deep RX FIFO when FJOIN_RX is set', async () => {
+      await resetStateMachines();
+      await cpu.writeUint32(SM0_SHIFTCTRL, FJOIN_RX);
+
+      // SET X, then IN X, 32 + PUSH eight times to fill the joined RX FIFO
+      await cpu.writeUint32(SM0_INSTR, pioSET(PIO_DEST_X, 0x15));
+      for (let i = 0; i < 8; i++) {
+        await cpu.writeUint32(SM0_INSTR, pioIN(PIO_SRC_X, 32));
+        await cpu.writeUint32(SM0_INSTR, pioPUSH(false, false));
+      }
+      expect(((await cpu.readUint32(FLEVEL)) >> RX0_SHIFT) & 0xf).toEqual(8); // RX0 level = 8
+      expect((await cpu.readUint32(FSTAT)) & FSTAT_RXFULL).toEqual(FSTAT_RXFULL);
+
+      // The donated TX FIFO is disabled: it reads back as both empty and full
+      expect((await cpu.readUint32(FSTAT)) & FSTAT_TXEMPTY).toEqual(FSTAT_TXEMPTY);
+      expect((await cpu.readUint32(FSTAT)) & FSTAT_TXFULL).toEqual(FSTAT_TXFULL);
+    });
+
+    it('should empty both FIFOs when the join configuration changes', async () => {
+      await resetStateMachines();
+
+      // Fill the (unjoined, 4-deep) TX FIFO
+      await cpu.writeUint32(TXF0, 1);
+      await cpu.writeUint32(TXF0, 2);
+      expect((await cpu.readUint32(FLEVEL)) & 0xf).toEqual(2);
+
+      // Joining the FIFOs clears them (datasheet §3.5.4)
+      await cpu.writeUint32(SM0_SHIFTCTRL, FJOIN_TX);
+      expect((await cpu.readUint32(FLEVEL)) & 0xf).toEqual(0);
+    });
   });
 });

--- a/src/peripherals/pio.ts
+++ b/src/peripherals/pio.ts
@@ -64,6 +64,12 @@ const SHIFTCTRL_AUTOPUSH = 1 << 16;
 const SHIFTCTRL_AUTOPULL = 1 << 17;
 const SHIFTCTRL_IN_SHIFTDIR = 1 << 18; // 1 = shift input shift register to right (data enters from left). 0 = to left
 const SHIFTCTRL_OUT_SHIFTDIR = 1 << 19; // 1 = shift out of output shift register to right. 0 = to left
+const SHIFTCTRL_FJOIN_RX = 1 << 30; // 1 = join RX FIFO with TX FIFO (8-deep RX, TX disabled)
+const SHIFTCTRL_FJOIN_TX = 1 << 31; // 1 = join TX FIFO with RX FIFO (8-deep TX, RX disabled)
+
+// FIFO depth, in 32-bit words
+const FIFO_DEPTH = 4;
+const FIFO_DEPTH_JOINED = 8;
 
 // EXECCTRL bits
 const EXECCTRL_STATUS_SEL = 1 << 4;
@@ -141,8 +147,10 @@ export class StateMachine {
   execCtrl = 0x1f << 12;
   shiftCtrl = 0b11 << 18;
   pinCtrl = 0x5 << 26;
-  readonly rxFIFO = new FIFO(4);
-  readonly txFIFO = new FIFO(4);
+  // Allocated at the joined depth; the usable depth is adjusted by updateFifoJoin()
+  // according to the FJOIN_TX / FJOIN_RX bits in SHIFTCTRL.
+  readonly rxFIFO = new FIFO(FIFO_DEPTH_JOINED);
+  readonly txFIFO = new FIFO(FIFO_DEPTH_JOINED);
 
   outPinValues: number = 0;
   outPinDirection: number = 0;
@@ -161,8 +169,36 @@ export class StateMachine {
     readonly pio: RPPIO,
     readonly index: number,
   ) {
+    this.updateFifoJoin();
     this.updateDMARx();
     this.updateDMATx();
+  }
+
+  /**
+   * Apply the FJOIN_TX / FJOIN_RX bits from SHIFTCTRL. When a direction is joined,
+   * its FIFO becomes 8 entries deep and the opposite direction is disabled (depth 0).
+   * If both bits are set, TX takes priority (the two halves can't both be donated).
+   * Reconfiguring the join empties both FIFOs, as on real hardware (datasheet §3.5.4).
+   */
+  updateFifoJoin() {
+    const joinTx = !!(this.shiftCtrl & SHIFTCTRL_FJOIN_TX);
+    const joinRx = !!(this.shiftCtrl & SHIFTCTRL_FJOIN_RX);
+    let txDepth = FIFO_DEPTH;
+    let rxDepth = FIFO_DEPTH;
+    if (joinTx) {
+      txDepth = FIFO_DEPTH_JOINED;
+      rxDepth = 0;
+    } else if (joinRx) {
+      txDepth = 0;
+      rxDepth = FIFO_DEPTH_JOINED;
+    }
+    if (txDepth === this.txFIFO.size && rxDepth === this.rxFIFO.size) {
+      return;
+    }
+    this.txFIFO.setCapacity(txDepth);
+    this.rxFIFO.setCapacity(rxDepth);
+    this.updateDMATx();
+    this.updateDMARx();
   }
 
   private updateDMATx() {
@@ -814,6 +850,7 @@ export class StateMachine {
         break;
       case SM0_SHIFTCTRL:
         this.shiftCtrl = value;
+        this.updateFifoJoin();
         break;
       case SM0_ADDR:
         /* read-only */

--- a/src/utils/fifo.ts
+++ b/src/utils/fifo.ts
@@ -3,13 +3,27 @@ export class FIFO {
 
   private start = 0;
   private used = 0;
+  private capacity: number;
 
   constructor(size: number) {
     this.buffer = new Uint32Array(size);
+    this.capacity = size;
   }
 
   get size() {
-    return this.buffer.length;
+    return this.capacity;
+  }
+
+  /**
+   * Change the usable depth of the FIFO, up to the size it was allocated with.
+   * Used by the PIO peripheral to implement FJOIN_TX / FJOIN_RX, where the two
+   * 4-deep FIFOs can be merged into a single 8-deep one. Reconfiguring the depth
+   * empties the FIFO, matching the RP2040 hardware behaviour.
+   */
+  setCapacity(capacity: number) {
+    this.capacity = Math.min(Math.max(capacity, 0), this.buffer.length);
+    this.start = 0;
+    this.used = 0;
   }
 
   get itemCount() {
@@ -19,7 +33,7 @@ export class FIFO {
   push(value: number) {
     const { length } = this.buffer;
     const { start, used } = this;
-    if (this.used < length) {
+    if (this.used < this.capacity) {
       this.buffer[(start + used) % length] = value;
       this.used++;
     }
@@ -49,7 +63,7 @@ export class FIFO {
   }
 
   get full() {
-    return this.used === this.buffer.length;
+    return this.used >= this.capacity;
   }
 
   get items() {


### PR DESCRIPTION
## Problem

The PIO state machines always expose two fixed 4-deep FIFOs and ignore the `FJOIN_TX` / `FJOIN_RX` bits in `SHIFTCTRL`. Programs that merge the two halves into a single 8-deep FIFO — a common idiom for deeper TX buffering or RX capture — observe the wrong depth, `FLEVEL`, and `FSTAT` full/empty flags.

## Change

- `FIFO` gains an adjustable usable depth (`setCapacity`) on top of its allocated buffer; `full` / `size` now honour it.
- `StateMachine` allocates 8-deep FIFOs and applies the join configuration via `updateFifoJoin()` on construction and on every `SHIFTCTRL` write. The joined direction becomes 8 deep, the donated direction is disabled (depth 0, reads back as both empty and full), and reconfiguring the join empties both FIFOs — matching the RP2040 datasheet (§3.5.4).

## Tests

Adds tests covering the 8-deep TX and RX joins, overflow / `TXOVER` behaviour, the disabled opposite direction, and FIFO clearing on reconfiguration.

---

For context: this came out of RP2040Sharp, a C# port of rp2040js, while differential-testing the PIO against real RP2040 silicon — the FIFO-join semantics here were validated against hardware. Contributing it back upstream.